### PR TITLE
rename scalepointai to modelserve

### DIFF
--- a/examples/beta-tests/create-node.json
+++ b/examples/beta-tests/create-node.json
@@ -10,7 +10,7 @@
                     {
                         "golem_workers.payloads.ClusterNodePayload": {
                             "runtime": "vm-nvidia",
-                            "image_tag": "scalepointai/automatic1111:4",
+                            "image_tag": "modelserve/automatic1111:4",
                             "subnet_tag": "golem-workers-beta",
                             "outbound_urls": [
                                  "https://gpu-provider.dev.golem.network"

--- a/examples/hello-example/create-node.json
+++ b/examples/hello-example/create-node.json
@@ -9,7 +9,7 @@
                 "payloads": [
                     {
                         "golem_workers.payloads.ClusterNodePayload": {
-                            "image_tag": "scalepointai/echo-test:2"
+                            "image_tag": "modelserve/echo-test:2"
                         }
                     }
                 ]

--- a/examples/sd-example/create-node.json
+++ b/examples/sd-example/create-node.json
@@ -10,7 +10,7 @@
                     {
                         "golem_workers.payloads.ClusterNodePayload": {
                             "runtime": "vm-nvidia",
-                            "image_tag": "scalepointai/automatic1111:4",
+                            "image_tag": "modelserve/automatic1111:4",
                             "outbound_urls": [
                                 "https://gpu-provider.dev.golem.network"
                             ]

--- a/golem_workers/entrypoints/web/endpoints.py
+++ b/golem_workers/entrypoints/web/endpoints.py
@@ -304,7 +304,7 @@ async def create_node(
         Body(
             openapi_examples={
                 "echo_test": {
-                    "summary": "scalepointai/echo-test:2",
+                    "summary": "modelserve/echo-test:2",
                     "description": "This example shows how to run echo test. It will use a VPN and proxy traffic from local machine to running vm at http://localhost:8080.",
                     "value": {
                         "cluster_id": "example",
@@ -319,7 +319,7 @@ async def create_node(
                                     "payloads": [
                                         {
                                             "golem_workers.payloads.ClusterNodePayload": {
-                                                "image_tag": "scalepointai/echo-test:2",
+                                                "image_tag": "modelserve/echo-test:2",
                                             },
                                         },
                                     ],
@@ -350,7 +350,7 @@ async def create_node(
                     },
                 },
                 "automatic": {
-                    "summary": "scalepointai/automatic1111:4",
+                    "summary": "modelserve/automatic1111:4",
                     "description": "This example shows how to run automatic with example model image. Automatic will take few minutes to download example model from Huggingface to provider. It will use a VPN and proxy traffic from local machine to running vm at http://localhost:8080.",
                     "value": {
                         "cluster_id": "example",
@@ -366,7 +366,7 @@ async def create_node(
                                         {
                                             "golem_workers.payloads.ClusterNodePayload": {
                                                 "runtime": "vm-nvidia",
-                                                "image_tag": "scalepointai/automatic1111:4",
+                                                "image_tag": "modelserve/automatic1111:4",
                                                 "outbound_urls": [
                                                     "https://gpu-provider.dev.golem.network",
                                                 ],

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Golem Workers Specification",
-    "version": "0.3.5a0"
+    "version": "0.3.5"
   },
   "paths": {
     "/": {

--- a/openapi.json
+++ b/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.1.0",
   "info": {
     "title": "Golem Workers Specification",
-    "version": "0.3.4"
+    "version": "0.3.5a0"
   },
   "paths": {
     "/": {
@@ -456,7 +456,7 @@
               },
               "examples": {
                 "echo_test": {
-                  "summary": "scalepointai/echo-test:2",
+                  "summary": "modelserve/echo-test:2",
                   "description": "This example shows how to run echo test. It will use a VPN and proxy traffic from local machine to running vm at http://localhost:8080.",
                   "value": {
                     "cluster_id": "example",
@@ -469,7 +469,7 @@
                           "payloads": [
                             {
                               "golem_workers.payloads.ClusterNodePayload": {
-                                "image_tag": "scalepointai/echo-test:2"
+                                "image_tag": "modelserve/echo-test:2"
                               }
                             }
                           ]
@@ -502,7 +502,7 @@
                   }
                 },
                 "automatic": {
-                  "summary": "scalepointai/automatic1111:4",
+                  "summary": "modelserve/automatic1111:4",
                   "description": "This example shows how to run automatic with example model image. Automatic will take few minutes to download example model from Huggingface to provider. It will use a VPN and proxy traffic from local machine to running vm at http://localhost:8080.",
                   "value": {
                     "cluster_id": "example",
@@ -516,7 +516,7 @@
                             {
                               "golem_workers.payloads.ClusterNodePayload": {
                                 "runtime": "vm-nvidia",
-                                "image_tag": "scalepointai/automatic1111:4",
+                                "image_tag": "modelserve/automatic1111:4",
                                 "outbound_urls": [
                                   "https://gpu-provider.dev.golem.network"
                                 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "golem-workers"
-version = "0.3.4"
+version = "0.3.5a0"
 description = "Golem Workers is an API providing direct and high-level access to CPU and GPU resources on the Golem Network."
 authors = ["Golem Factory <contact@golem.network>"]
 readme = "README.md"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "golem-workers"
-version = "0.3.5a0"
+version = "0.3.5"
 description = "Golem Workers is an API providing direct and high-level access to CPU and GPU resources on the Golem Network."
 authors = ["Golem Factory <contact@golem.network>"]
 readme = "README.md"


### PR DESCRIPTION
In this PR:
- [x] changed `scalepointai` to `modelserve` 
  - [x] in example jsons
  - [x] in openapi spec
- [x] bumped version