### PR TITLE
chore: Update Python and golem-node dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,12 +19,12 @@ url = "https://test.pypi.org/simple/"
 priority = "explicit"
 
 [tool.poetry.dependencies]
-python = "^3.8.1"
+python = "^3.10"
 
 #golem-core = {path = "../golem-core-python", develop = true}
 #golem-core = {git = "https://github.com/golemfactory/golem-core-python.git", branch = "approxit/cluster-api"}
 golem-core = "^0.7.6"
-golem-node = "^0.16.0"
+golem-node = "^0.17.0"
 
 fastapi = "^0.111.0"
 pydantic-settings = "^2.3.1"


### PR DESCRIPTION
- Update Python dependency version from `3.8.1` to `3.10`
- Update golem-node dependency version from `0.16.0` to `0.17.0`